### PR TITLE
msg display for pop up block

### DIFF
--- a/src/components/CommandLine.js
+++ b/src/components/CommandLine.js
@@ -1,13 +1,12 @@
+import { useState } from 'react'
 import styles from '../css/CommandLine.module.css'
 import Typist from 'react-typist'
 
-const CommandLine = ({ onClose }) => {
-
+const CommandLine = () => {
+  const [secondMsg, setMsg] = useState(false)
   const redirect = () => {
-    setTimeout(() => {
-      // onClose()
-      // window.open('https://form.typeform.com/to/HHCYD0tv', '_blank')
-    }, 750)
+    window.open('https://stormhacks.typeform.com/to/GWfDap3w', '_blank')
+    setMsg(true)
   }
 
   return (
@@ -25,8 +24,7 @@ const CommandLine = ({ onClose }) => {
           show: true,
           blink: false,
           element: '▌',
-          hideWhenDone: false,
-          hideWhenDoneDelay: 1000
+          hideWhenDone: true
         }}
         onTypingDone={redirect}
       >
@@ -49,10 +47,48 @@ const CommandLine = ({ onClose }) => {
         <Typist.Delay ms={200} />
         <span className={styles.fontAnimated}> . </span>
         <br />
-        <span className={styles.fontAnimated}> Applications are not open until December 28th.</span>
-        <br />
-        <span className={styles.fontAnimated}> process exited with code 1</span>
+        <span className={styles.fontAnimated}>Opening Application</span>
+        <Typist.Delay ms={200} />
+        <span className={styles.fontAnimated}> . </span>
+        <Typist.Delay ms={200} />
+        <span className={styles.fontAnimated}> . </span>
+        <Typist.Delay ms={200} />
+        <span className={styles.fontAnimated}> . </span>
+        <Typist.Delay ms={200} />
+        <span className={styles.fontAnimated}> . </span>
       </Typist>
+
+      {secondMsg && (
+        <Typist
+          className={styles.typist}
+          avgTypingDelay={1}
+          stdTypingDelay={10}
+          cursor={{
+            show: true,
+            blink: false,
+            element: '▌',
+            hideWhenDone: false
+          }}
+        >
+          <br />
+          <br />
+          <Typist.Delay ms={500} />
+          <span className={styles.fontAnimated}>
+            If the application form has not appeared, please make sure that
+            popups are enabled or click the following link:
+          </span>
+          <br />
+          <a
+            href="https://stormhacks.typeform.com/to/GWfDap3w"
+            target="_blank"
+            rel="noreferrer"
+            className={styles.linkAnimated}
+          >
+            https://stormhacks.typeform.com/to/GWfDap3w
+          </a>
+          <br />
+        </Typist>
+      )}
     </div>
   )
 }

--- a/src/components/DesktopFile.js
+++ b/src/components/DesktopFile.js
@@ -19,7 +19,7 @@ const DesktopFile = ({ Content, ...props }) => {
     <>
       {isOpen && (
         <Modal title={props.text} onClose={closeFile}>
-          <Content onClose={closeFile} />
+          <Content />
         </Modal>
       )}
       <div className={styles.container} onClick={openFile}>

--- a/src/css/CommandLine.module.css
+++ b/src/css/CommandLine.module.css
@@ -24,6 +24,11 @@
   color: var(--color-text-body);
 }
 
+.linkAnimated {
+  font: var(--font-body);
+  color: var(--color-text-body);
+}
+
 .typist span {
   color: var(--color-text-body);
 }


### PR DESCRIPTION
This branch addresses the pop-up blocker problem. Ie. if the user has a pop up blocker, the typeform won't automatically open.  So this just displays a short msg at the end of the commandline modal telling the user to allow popups and also displays the link to the typeform just in case. Feel free to make any changes to the message displayed to the users or anything else with the code, and double-check if it works on your end. 